### PR TITLE
Adopt it for 5.5 and other improvements for "Cast" and "NonNull"

### DIFF
--- a/Source/IGRanges/Private/Tests/IGRanges_NonNull.spec.cpp
+++ b/Source/IGRanges/Private/Tests/IGRanges_NonNull.spec.cpp
@@ -58,7 +58,7 @@ bool TestRefs(const RangeType& Range)
 	}
 
 	int32 i = -1;
-	for (auto& X : Range | NonNullRef())
+	for (auto&& X : Range | NonNullRef())
 	{
 		++i;
 		UTEST_TRUE_EXPR(ExpectedPointers.IsValidIndex(i));
@@ -66,11 +66,11 @@ bool TestRefs(const RangeType& Range)
 		// Use `TestSame` (not `TestEqual`) because these are supposed to be references to the same object.
 		if constexpr (TIsTWeakPtr_V<T>) // Support for `TWeakPtr`
 		{
-			UTEST_SAME("non-null element", X, *ExpectedPointers[i].Pin().Get());
+			UTEST_SAME("non-null element", X.get(), *ExpectedPointers[i].Pin().Get());
 		}
 		else
 		{
-			UTEST_SAME("non-null element", X, *ExpectedPointers[i]);
+			UTEST_SAME("non-null element", X.get(), *ExpectedPointers[i]);
 		}
 	}
 

--- a/Source/IGRanges/Public/IGRanges/Cast.h
+++ b/Source/IGRanges/Public/IGRanges/Cast.h
@@ -47,7 +47,7 @@ template <class T>
 template <class T>
 [[nodiscard]] constexpr auto CastCheckedRef()
 {
-	return std::views::transform([](auto&& x) -> T& { return *::CastChecked<T>(x); });
+	return std::views::transform([](auto&& x) -> decltype(auto) { return std::ref(*::CastChecked<T>(x)); });
 }
 
 /**
@@ -56,7 +56,7 @@ template <class T>
 template <class T>
 [[nodiscard]] constexpr auto CastChecked(ECastCheckedType::Type CheckType)
 {
-	return std::views::transform([](auto&& x) { return ::CastChecked<T>(x, CheckType); });
+	return std::views::transform([CheckType](auto&& x) { return ::CastChecked<T>(x, CheckType); });
 }
 
 // Note: There is no `CastCheckedRef(ECastCheckedType::Type)` because it allows for null-in / null-out.

--- a/Source/IGRanges/Public/IGRanges/NonNull.h
+++ b/Source/IGRanges/Public/IGRanges/NonNull.h
@@ -25,12 +25,12 @@ struct NonNullRef_fn
 			{
 				return std::forward<RangeType>(Range)
 					 | std::views::filter([](auto&& x) { return x.IsValid(); })
-					 | std::views::transform([](auto&& x) -> typename T::ElementType& { return *x.Pin().Get(); });
+					 | std::views::transform([](auto&& x) -> decltype(auto) { return std::ref(*x.Pin().Get()); });
 			}
 			else
 			{
 				return std::forward<RangeType>(Range)
-					 | std::views::transform([](auto&& x) -> typename T::ElementType& { return *x.Pin().Get(); });
+					 | std::views::transform([](auto&& x) -> decltype(auto) { return std::ref(*x.Pin().Get()); });
 			}
 		}
 		else
@@ -39,12 +39,12 @@ struct NonNullRef_fn
 			{
 				return std::forward<RangeType>(Range)
 					 | std::views::filter([](auto&& x) { return x != nullptr; })
-					 | std::views::transform([](auto&& x) -> decltype(*x)& { return *x; });
+					 | std::views::transform([](auto&& x) -> decltype(auto) { return std::ref(*x); });
 			}
 			else
 			{
 				return std::forward<RangeType>(Range)
-					 | std::views::transform([](auto&& x) -> decltype(*x)& { return *x; });
+					 | std::views::transform([](auto&& x) -> decltype(auto) { return std::ref(*x); });
 			}
 		}
 	}


### PR DESCRIPTION
- Changed: adopt changes for 5.5

- Improvement: [Cast] skip casting if same type

- New: [NonNull] add ToRef which return reference without validating pointer

- New: [Cast] implement tests for more kinds of Cast