### PR TITLE
removed XxxRef versions

### DIFF
--- a/IGRanges.uplugin
+++ b/IGRanges.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 1,
-	"VersionName": "1.0",
+	"Version": 2,
+	"VersionName": "2.0",
 	"FriendlyName": "C++ Ranges for Unreal",
 	"Description": "Library that leverages Ranges (C++20) to provide LINQ (C#) style code patterns.",
 	"Category": "Programming",

--- a/Source/IGRanges/Private/Tests/IGRanges_NonNull.spec.cpp
+++ b/Source/IGRanges/Private/Tests/IGRanges_NonNull.spec.cpp
@@ -38,45 +38,6 @@ bool TestPointers(const RangeType& Range)
 	return true;
 }
 
-/**
- * Given a range of pointer-like elements, tests that `NonNullRef` behaves the same as a null-check.
- */
-template <typename RangeType>
-bool TestRefs(const RangeType& Range)
-{
-	using namespace IG::Ranges;
-
-	using T = std::ranges::range_value_t<RangeType>;
-
-	TArray<T> ExpectedPointers;
-	for (auto&& X : Range)
-	{
-		if (X != nullptr)
-		{
-			ExpectedPointers.Emplace(X);
-		}
-	}
-
-	int32 i = -1;
-	for (auto& X : Range | NonNullRef())
-	{
-		++i;
-		UTEST_TRUE_EXPR(ExpectedPointers.IsValidIndex(i));
-
-		// Use `TestSame` (not `TestEqual`) because these are supposed to be references to the same object.
-		if constexpr (TIsTWeakPtr_V<T>) // Support for `TWeakPtr`
-		{
-			UTEST_SAME("non-null element", X, *ExpectedPointers[i].Pin().Get());
-		}
-		else
-		{
-			UTEST_SAME("non-null element", X, *ExpectedPointers[i]);
-		}
-	}
-
-	return true;
-}
-
 END_DEFINE_SPEC(FIGRangesNonNullSpec)
 
 void FIGRangesNonNullSpec::Define()
@@ -113,40 +74,6 @@ void FIGRangesNonNullSpec::Define()
 
 		auto SomeWeakPointers = SomePointers | std::views::transform([](auto&& x) { return x.ToWeakPtr(); });
 		TestPointers(SomeWeakPointers);
-	});
-
-	// `NonNullRef` yields references to non-null elements' data.
-	It("removes_null_pointers_yields_refs", [this]() {
-		int32 A = 1;
-		int32 B = 2;
-		int32 C = 3;
-		int32 D = 4;
-		const int32* SomePointers[] = {nullptr, &A, &B, &C, &D, nullptr, nullptr, &D, &A, &D};
-
-		TestRefs(SomePointers);
-	});
-
-	// `NonNullRef` yields references to shared pointers' data.
-	It("removes_null_shared_pointers_yields_refs", [this]() {
-		TSharedPtr<int32> A = MakeShared<int32>(1);
-		TSharedPtr<int32> B = MakeShared<int32>(2);
-		TSharedPtr<int32> C = MakeShared<int32>(3);
-		TSharedPtr<int32> D = MakeShared<int32>(4);
-		const TSharedPtr<int32> SomePointers[] = {nullptr, A, B, C, D, nullptr, nullptr, D, A, D};
-
-		TestRefs(SomePointers);
-	});
-
-	// `NonNullRef` yields references to weak pointers' data.
-	It("removes_null_weak_pointers_yields_refs", [this]() {
-		TSharedPtr<int32> A = MakeShared<int32>(1);
-		TSharedPtr<int32> B = MakeShared<int32>(2);
-		TSharedPtr<int32> C = MakeShared<int32>(3);
-		TSharedPtr<int32> D = MakeShared<int32>(4);
-		const TSharedPtr<int32> SomePointers[] = {nullptr, A, B, C, D, nullptr, nullptr, D, A, D};
-		auto SomeWeakPointers = SomePointers | std::views::transform([](auto&& x) { return x.ToWeakPtr(); });
-
-		TestRefs(SomeWeakPointers);
 	});
 }
 

--- a/Source/IGRanges/Private/Tests/IGRanges_OfType.spec.cpp
+++ b/Source/IGRanges/Private/Tests/IGRanges_OfType.spec.cpp
@@ -58,53 +58,6 @@ void TestPointers()
 }
 
 /**
- * Given a range of pointer-like elements, tests that `OfTypeRef` behaves the same as `Cast`.
- */
-template <class T, typename RangeType>
-bool TestRefsOfType(const RangeType& Range)
-{
-	using namespace IG::Ranges;
-
-	TArray<const T*> ExpectedPointers;
-	for (auto&& X : Range)
-	{
-		if (auto* Casted = Cast<T>(X))
-		{
-			ExpectedPointers.Emplace(Casted);
-		}
-	}
-
-	int32 i = -1;
-	for (auto& X : Range | OfTypeRef<T>())
-	{
-		++i;
-		UTEST_TRUE_EXPR(ExpectedPointers.IsValidIndex(i));
-
-		// Use `TestSame` (not `TestEqual`) because these are supposed to be references to the same object.
-		UTEST_SAME("casted element", X, *ExpectedPointers[i]);
-	}
-
-	UTEST_EQUAL("count", i + 1, ExpectedPointers.Num());
-
-	return true;
-}
-
-/**
- * Same as `TestPointers` but tests `OfTypeRef`.
- */
-template <typename PointerType>
-void TestRefs()
-{
-	PointerType A = GetDefault<UObject>();
-	PointerType B = GetDefault<UClass>();
-	PointerType C = GetDefault<UPackage>();
-	PointerType D = GetDefault<UMetaData>();
-	PointerType SomePointers[] = {nullptr, A, B, C, D, nullptr, nullptr, D, A, D};
-
-	TestRefsOfType<const UMetaData>(SomePointers);
-}
-
-/**
  * Given a range of pointer-like elements, tests that `OfType` behaves the same as `IsA`.
  */
 template <typename RangeType>
@@ -168,21 +121,6 @@ void FIGRangesOfTypeSpec::Define()
 	// `OfType` yields only pointers to objects of the specified type.
 	It("yields_objects_of_specified_type (TWeakObjectPtr)", [this]() {
 		TestPointers<TWeakObjectPtr<const UObject>>();
-	});
-
-	// `OfType` yields only references to objects of the specified type.
-	It("yields_references_to_objects_of_specified_type (raw pointer)", [this]() {
-		TestRefs<const UObject*>();
-	});
-
-	// `OfType` yields only references to objects of the specified type.
-	It("yields_references_to_objects_of_specified_type (TObjectPtr)", [this]() {
-		TestRefs<TObjectPtr<const UObject>>();
-	});
-
-	// `OfType` yields only references to objects of the specified type.
-	It("yields_references_to_objects_of_specified_type (TWeakObjectPtr)", [this]() {
-		TestRefs<TWeakObjectPtr<const UObject>>();
 	});
 
 	// `OfType` yields only pointers to objects of the specified class.

--- a/Source/IGRanges/Public/IGRanges/Cast.h
+++ b/Source/IGRanges/Public/IGRanges/Cast.h
@@ -42,15 +42,6 @@ template <class T>
 }
 
 /**
- * Same as `CastChecked<T>` but yields references to values instead of pointers.
- */
-template <class T>
-[[nodiscard]] constexpr auto CastCheckedRef()
-{
-	return std::views::transform([](auto&& x) -> T& { return *::CastChecked<T>(x); });
-}
-
-/**
  * Similar to `CastChecked<T>` (no parameters) but null-check behavior is parameterized.
  */
 template <class T>
@@ -58,7 +49,5 @@ template <class T>
 {
 	return std::views::transform([](auto&& x) { return ::CastChecked<T>(x, CheckType); });
 }
-
-// Note: There is no `CastCheckedRef(ECastCheckedType::Type)` because it allows for null-in / null-out.
 
 } // namespace IG::Ranges

--- a/Source/IGRanges/Public/IGRanges/NonNull.h
+++ b/Source/IGRanges/Public/IGRanges/NonNull.h
@@ -9,32 +9,6 @@
 
 namespace IG::Ranges
 {
-namespace Private
-{
-struct NonNullRef_fn
-{
-	template <typename RangeType>
-	[[nodiscard]] constexpr auto operator()(RangeType&& Range) const
-	{
-		using T = std::ranges::range_value_t<RangeType>;
-
-		if constexpr (TIsTWeakPtr_V<T>) // Support for `TWeakPtr`
-		{
-			return std::forward<RangeType>(Range)
-				 | std::views::filter([](auto&& x) { return x.IsValid(); })
-				 | std::views::transform([](auto&& x) -> T::ElementType& { return *x.Pin().Get(); });
-		}
-		else
-		{
-			return std::forward<RangeType>(Range)
-				 | std::views::filter([](auto&& x) { return x != nullptr; })
-				 | std::views::transform([](auto&& x) -> decltype(*x)& { return *x; });
-		}
-	}
-};
-
-} // namespace Private
-
 /**
  * Filters a sequence of pointer-like values, removing null elements.
  * Works on raw pointers (e.g. `UFoo*`) and smart pointers (e.g. `TObjectPtr<UFoo>`, `TWeakPointer<FBar>`, etc.) and
@@ -52,14 +26,6 @@ struct NonNullRef_fn
 			return x != nullptr;
 		}
 	});
-}
-
-/**
- * Same as `NonNull` but yields references to values instead of pointers.
- */
-[[nodiscard]] inline constexpr auto NonNullRef()
-{
-	return std::ranges::_Range_closure<_IGRP NonNullRef_fn>{};
 }
 
 } // namespace IG::Ranges

--- a/Source/IGRanges/Public/IGRanges/OfType.h
+++ b/Source/IGRanges/Public/IGRanges/OfType.h
@@ -36,11 +36,6 @@ template <typename T>
 	return _IGRP IsA(SoftObj.Get(), Class);
 }
 
-[[nodiscard]] inline constexpr auto Dereference()
-{
-	return std::views::transform([](auto&& x) -> decltype(*x)& { return *x; });
-}
-
 [[nodiscard]] inline constexpr auto NonNull()
 {
 	return std::views::filter([](const void* x) { return x != nullptr; });
@@ -66,15 +61,6 @@ template <class T>
 }
 
 /**
- * Same as `OfType<T>` but yields references to values instead of pointers.
- */
-template <class T>
-[[nodiscard]] constexpr auto OfTypeRef()
-{
-	return _IGR Cast<T>() | _IGRP NonNull() | _IGRP Dereference();
-}
-
-/**
  * Similar to `OfType<T>` but uses `ExactCast<T>`.
  */
 template <class T>
@@ -84,28 +70,11 @@ template <class T>
 }
 
 /**
- * Same as `OfExactType<T>` but yields references to values instead of pointers.
- */
-template <class T>
-[[nodiscard]] constexpr auto OfExactTypeRef()
-{
-	return _IGR ExactCast<T>() | _IGRP NonNull() | _IGRP Dereference();
-}
-
-/**
  * Similar to `OfType<T>` (checks types) but does not perform a cast.
  */
 [[nodiscard]] inline constexpr auto OfType(const UClass* Class)
 {
 	return std::views::filter([Class](auto&& x) { return _IGRP IsA(x, Class); });
-}
-
-/**
- * Similar to `OfType` (one parameter) but yields references to values instead of pointers.
- */
-[[nodiscard]] inline constexpr auto OfTypeRef(const UClass* Class)
-{
-	return _IGR OfType(Class) | _IGRP Dereference();
 }
 
 } // namespace IG::Ranges


### PR DESCRIPTION
This is a breaking change.
Things like `NonNullRef` have been removed.
The "ref" versions have been removed because I decided they don't serve the Unreal ecosystem well, which primarily deals with pointers.